### PR TITLE
aarch64 support

### DIFF
--- a/Sources/SwiftyTailwind/ArchitectureDetector.swift
+++ b/Sources/SwiftyTailwind/ArchitectureDetector.swift
@@ -3,13 +3,14 @@ import TSCBasic
 import TSCUtility
 
 public enum CpuArchitecture: String, Hashable  {
+    case aarch64   = "aarch64"
     case arm64   = "arm64"
     case armv7   = "armv7"
     case x86_64   = "x86_64"
     
     var tailwindValue: String {
         switch self {
-        case .arm64: return "arm64"
+        case .arm64, .aarch64: return "arm64"
         case .armv7: return "armv7"
         case .x86_64: return "x64"
         }


### PR DESCRIPTION
Adds a `aarch64` case to the `CpuArchitecture` which resolves #15.

Based on [my reading](https://www.xda-developers.com/aarch64/) aarch64 and arm64 synonymous so I've returned "arm64" for the `tailwindValue` and I works as expected in a dev container.