### PR TITLE
Update docs to run Vapor and Tailwind watch in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Check out all the available options in the [documentation](https://swiftytailwin
 
 ### Integrating with Vapor
 
-You can integrate this with Vapor by setting up a `tailwind.swift`
+You can integrate this with Vapor by setting up a `tailwind.swift`:
 
 ```swift
 import SwiftyTailwind
@@ -66,26 +66,26 @@ import TSCBasic
 import Vapor
 
 func tailwind(_ app: Application) async throws {
-  let resourecesDirectory = try AbsolutePath(validating: app.directory.resourcesDirectory)
+  let resourcesDirectory = try AbsolutePath(validating: app.directory.resourcesDirectory)
   let publicDirectory = try AbsolutePath(validating: app.directory.publicDirectory)
 
   let tailwind = SwiftyTailwind()
   try await tailwind.run(
-    input: .init(validating: "Styles/app.css", relativeTo: resourecesDirectory),
+    input: .init(validating: "Styles/app.css", relativeTo: resourcesDirectory),
     output: .init(validating: "styles/app.generated.css", relativeTo: publicDirectory),
     options: .content("\(app.directory.viewsDirectory)/**/*.leaf")
   )
 }
 ```
 
-Then in `configure.swift`
+Then in `configure.swift`:
 
 ```swift
 try await tailwind(app)
 app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
 ```
 
-And in your `index.leaf`
+And in your `index.leaf`:
 
 ```html
 <link rel="stylesheet" href="/styles/app.generated.css" />


### PR DESCRIPTION
resolves #27 

### Changes
- Fixed a typo and added some colons (for consistency)
- Defined a `runTailwind` function in `tailwind.swift` wrapped in a `DEBUG` flag
- Added changes in `entrypoint.swift` and another `DEBUG` flag

### Tests
I tested this by running both `swift run App serve` and `swift run App migrate` in development, as well as deploying a docker container and confirming that Tailwind was not being run in the production environment.

### Note
I'm curious if I need the extra `DEBUG` flag in `tailwind.swift` that only defines the function. Will Swift still  compile and bring in dependencies if the file contains a function that has only been defined and not used? Also, I am not sure if the code I wrote is the most optimal and most aligning with Swifty standards, so I am very open to any adjustments.