### PR TITLE
Added checksum validation for the downloader

### DIFF
--- a/Examples/PublishExample/Package.resolved
+++ b/Examples/PublishExample/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "78db67e5bf4a8543075787f228e8920097319281",
-        "version" : "1.18.0"
+        "revision" : "a22083713ee90808d527d0baa290c2fb13ca3096",
+        "version" : "1.21.1"
       }
     },
     {
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms",
+      "state" : {
+        "revision" : "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
-        "version" : "1.5.2"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "6213ba7a06febe8fef60563a4a7d26a4085783cf",
-        "version" : "2.54.0"
+        "revision" : "702cd7c56d5d44eeba73fdf83918339b26dc855c",
+        "version" : "2.62.0"
       }
     },
     {
@@ -149,8 +158,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "41f4098903878418537020075a4d8a6e20a0b182",
-        "version" : "1.17.0"
+        "revision" : "6cbe0ed2b394f21ab0d46b9f0c50c6be964968ce",
+        "version" : "1.20.1"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
+        "version" : "1.0.2"
       }
     },
     {
@@ -167,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-tools-support-core.git",
       "state" : {
-        "revision" : "93784c59434dbca8e8a9e4b700d0d6d94551da6a",
-        "version" : "0.5.2"
+        "revision" : "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
+        "version" : "0.6.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "5ccda442f103792d67680aefc8d0a87392fbd66c",
-        "version" : "1.20.0"
+        "revision" : "a22083713ee90808d527d0baa290c2fb13ca3096",
+        "version" : "1.21.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "532d8b529501fb73a2455b179e0bbb6d49b652ed",
-        "version" : "1.5.3"
+        "revision" : "e97a6fcb1ab07462881ac165fdbb37f067e205d5",
+        "version" : "1.5.4"
       }
     },
     {

--- a/Sources/SwiftyTailwind/ChecksumValidation.swift
+++ b/Sources/SwiftyTailwind/ChecksumValidation.swift
@@ -1,5 +1,4 @@
 import Foundation
-import CommonCrypto
 import TSCBasic
 
 protocol ChecksumValidating {
@@ -9,46 +8,24 @@ protocol ChecksumValidating {
 
 struct ChecksumValidation: ChecksumValidating {
     func generateChecksumFrom(_ filePath: AbsolutePath) throws -> String {
-        let binaryData = try Data(contentsOf: filePath.asURL)
-        return binaryData.sha256()
+        let checksumGenerationTask = Process()
+        checksumGenerationTask.launchPath = "shasum"
+        checksumGenerationTask.arguments = ["-a", "256", filePath.pathString]
+        
+        let pipe = Pipe()
+        checksumGenerationTask.standardOutput = pipe
+        checksumGenerationTask.launch()
+        
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard let output = String(data: data, encoding: String.Encoding.utf8) else {
+            throw DownloaderError.errorReadingFilesForChecksumValidation
+        }
+        
+        return output
     }
     
     func compareChecksum(from filePath: AbsolutePath, to checksum: String) throws -> Bool {
         let checksumString = try String(contentsOf: filePath.asURL)
-        return checksum == checksumString.sha256()
-    }
-}
-
-extension Data{
-    public func sha256() -> String{
-        return hexStringFromData(input: digest(input: self as NSData))
-    }
-    
-    private func digest(input : NSData) -> NSData {
-        let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
-        var hash = [UInt8](repeating: 0, count: digestLength)
-        CC_SHA256(input.bytes, UInt32(input.length), &hash)
-        return NSData(bytes: hash, length: digestLength)
-    }
-    
-    private  func hexStringFromData(input: NSData) -> String {
-        var bytes = [UInt8](repeating: 0, count: input.length)
-        input.getBytes(&bytes, length: input.length)
-        
-        var hexString = ""
-        for byte in bytes {
-            hexString += String(format:"%02x", UInt8(byte))
-        }
-        
-        return hexString
-    }
-}
-
-extension String {
-    func sha256() -> String{
-        if let stringData = self.data(using: String.Encoding.utf8) {
-            return stringData.sha256()
-        }
-        return ""
+        return checksum == checksumString
     }
 }

--- a/Sources/SwiftyTailwind/ChecksumValidation.swift
+++ b/Sources/SwiftyTailwind/ChecksumValidation.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Brady Klein on 5/10/24.
-//
-
 import Foundation
 import CommonCrypto
 import TSCBasic

--- a/Sources/SwiftyTailwind/ChecksumValidation.swift
+++ b/Sources/SwiftyTailwind/ChecksumValidation.swift
@@ -9,7 +9,7 @@ protocol ChecksumValidating {
 struct ChecksumValidation: ChecksumValidating {
     func generateChecksumFrom(_ filePath: AbsolutePath) throws -> String {
         let checksumGenerationTask = Process()
-        checksumGenerationTask.launchPath = "shasum"
+        checksumGenerationTask.launchPath = "/usr/bin/shasum"
         checksumGenerationTask.arguments = ["-a", "256", filePath.pathString]
         
         let pipe = Pipe()

--- a/Sources/SwiftyTailwind/ChecksumValidation.swift
+++ b/Sources/SwiftyTailwind/ChecksumValidation.swift
@@ -5,8 +5,8 @@
 //  Created by Brady Klein on 5/10/24.
 //
 
-import CommonCrypto
 import Foundation
+import CommonCrypto
 import TSCBasic
 
 protocol ChecksumValidating {

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -23,7 +23,7 @@ enum DownloaderError: LocalizedError {
         case .checksumIsIncorrect:
             return "We attempted 5 downloads of the binary but the checksum never matched. Aborting."
         case .errorReadingFilesForChecksumValidation:
-            return "We were unable to read files for checksum validation. Aborting."
+            return "We were unable to read files for checksum validation."
         }
     }
 }

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -21,7 +21,7 @@ enum DownloaderError: LocalizedError {
         case .unableToDetermineBinaryName:
             return "We were unable to determine Tailwind's binary name for this architecture and OS."
         case .checksumIsIncorrect:
-            return "We attempted 5 downloads of the binary but the checksum never matched. Aborting."
+            return "We attempted 5 downloads of the binary but the checksum never matched."
         case .errorReadingFilesForChecksumValidation:
             return "We were unable to read files for checksum validation."
         }

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -77,7 +77,7 @@ class Downloader: Downloading {
         try await downloadChecksumFile(version: expectedVersion, to: checksumPath)
         do {
             let binaryChecksum = try Self.checksumValidator.generateChecksumFrom(binaryPath)
-            guard Self.checksumValidator.compareChecksum(from: checksumPath, to: binaryChecksum) else {
+            guard try Self.checksumValidator.compareChecksum(from: checksumPath, to: binaryChecksum) else {
                 
                 if numRetries < 5 {
                     // retry download

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -81,8 +81,8 @@ class Downloader: Downloading {
                 
                 if numRetries < 5 {
                     // retry download
-                    numRetries += 1
                     logger.error("Checksum validation failed. Attempt #\(numRetries + 1) to retry download...")
+                    numRetries += 1
                     return try await download(version: version, directory: binaryPath)
                 } else {
                     throw DownloaderError.checksumIsIncorrect

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -13,11 +13,17 @@ enum DownloaderError: LocalizedError {
      This error is thrown when the binary name cannot be determined.
      */
     case unableToDetermineBinaryName
+    case checksumIsIncorrect
+    case errorReadingFilesForChecksumValidation
     
     var errorDescription: String? {
         switch self {
         case .unableToDetermineBinaryName:
             return "We were unable to determine Tailwind's binary name for this architecture and OS."
+        case .checksumIsIncorrect:
+            return "We attempted 5 downloads of the binary but the checksum never matched. Aborting."
+        case .errorReadingFilesForChecksumValidation:
+            return "We were unable to read files for checksum validation. Aborting."
         }
     }
 }
@@ -44,6 +50,10 @@ class Downloader: Downloading {
         return try! localFileSystem.tempDirectory.appending(component: "SwiftyTailwind")
     }
     
+    static let sha256FileName: String = "sha256sums.txt"
+    static let checksumValidator: ChecksumValidating = ChecksumValidation()
+    var numRetries = 0
+    
     init(architectureDetector: ArchitectureDetecting = ArchitectureDetector()) {
         self.architectureDetector = architectureDetector
         self.logger = Logger(label: "io.tuist.SwiftyTailwind.Downloader")
@@ -63,6 +73,24 @@ class Downloader: Downloading {
         let binaryPath = directory.appending(components: [expectedVersion, binaryName])
         if localFileSystem.exists(binaryPath) { return binaryPath }
         try await downloadBinary(name: binaryName, version: expectedVersion, to: binaryPath)
+        let checksumPath = directory.appending(components: [expectedVersion, Self.sha256FileName])
+        try await downloadChecksumFile(version: expectedVersion, to: checksumPath)
+        do {
+            let binaryChecksum = try Self.checksumValidator.generateChecksumFrom(binaryPath)
+            guard Self.checksumValidator.compareChecksum(from: checksumPath, to: binaryChecksum) else {
+                
+                if numRetries < 5 {
+                    // retry download
+                    numRetries += 1
+                    logger.error("Checksum validation failed. Attempt #\(numRetries + 1) to retry download...")
+                    return try await download(version: version, directory: binaryPath)
+                } else {
+                    throw DownloaderError.checksumIsIncorrect
+                }
+            }
+        } catch {
+            logger.error("Error accessing checksum file or binary for checksum validation. Error: \(error.localizedDescription)")
+        }
         return binaryPath
     }
     
@@ -98,6 +126,10 @@ class Downloader: Downloading {
             throw error
         }
         try await client.shutdown()
+    }
+    
+    private func downloadChecksumFile(version: String, to downloadPath: AbsolutePath) async throws {
+        try await downloadBinary(name: Self.sha256FileName, version: version, to: downloadPath)
     }
     
     /**

--- a/Sources/SwiftyTailwind/Downloader.swift
+++ b/Sources/SwiftyTailwind/Downloader.swift
@@ -128,7 +128,7 @@ class Downloader: Downloading {
         try await client.shutdown()
     }
     
-    private func downloadChecksumFile(version: String, to downloadPath: AbsolutePath) async throws {
+    private func downloadChecksumFile(version: String, into downloadPath: AbsolutePath) async throws {
         try await downloadBinary(name: Self.sha256FileName, version: version, to: downloadPath)
     }
     

--- a/Sources/SwiftyTailwind/SwiftyTailwind.swift
+++ b/Sources/SwiftyTailwind/SwiftyTailwind.swift
@@ -78,7 +78,7 @@ public class SwiftyTailwind {
      Downloads the Tailwind portable executable
      */
     private func download() async throws -> AbsolutePath {
-        try await downloader.download(version: version, directory: directory)
+        try await downloader.download(version: version, directory: directory, numRetries: 0)
     }
 }
 


### PR DESCRIPTION
# Summary
Added checksum validation. I gave 5 attempts at downloading the binary as that seemed reasonable to me.

## Testing performed
Tested by changing version of SwiftyTailwind to use my remote branch, deleting the binary, then allowing the code to execute in a test vapor project. Below is CLI output, with which you can verify the expected behavior.

## Expected change
The tool should automatically download the sha256 checksum in addition to the binary, then automatically compare the sha256 that was downloaded to the generated sha256 checksum of the binary. This should be attempted up to 5 times. If there are further errors, I chose to cause an error rather than continue trying infinitely.

## Actual change
```bash
[ ERROR ] Checksum validation failed. Attempt #1 to retry download...
[ ERROR ] Error accessing checksum file or binary for checksum validation. Error: The file “tailwindcss-macos-arm64” couldn’t be saved in the folder “v3.4.3”.
[ INFO ] Tailwind: /[censored]/SwiftyTailwind/v3.4.3/tailwindcss-macos-arm64 init
[ INFO ] 

[ INFO ] tailwind.config.js already exists.

[ INFO ] Tailwind: /[censored]/SwiftyTailwind/v3.4.3/tailwindcss-macos-arm64 --input /[censored]/hello/Resources/Styles/app.css --output /[censored]/hello/Public/styles/app.generated.css --content /[censored]/hello/Resources/Views/**/*.leaf --no-autoprefixer
[ INFO ] 

[ INFO ] Rebuilding...

[ INFO ] 

[ INFO ] Done in 53ms.

[ NOTICE ] Server starting on http://127.0.0.1:8080
[ INFO ] Tailwind: /[censored]/SwiftyTailwind/v3.4.3/tailwindcss-macos-arm64 --input /[censored]/hello/Resources/Styles/app.css --output /[censored]/hello/Public/styles/app.generated.css --watch --content /[censored]/hello/Resources/Views/**/*.leaf --no-autoprefixer
[ INFO ] 

[ INFO ] Rebuilding...

[ INFO ] 

[ INFO ] Done in 55ms.
```